### PR TITLE
dont let heartbeat errors crash consumer

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -226,7 +226,7 @@ export class Consumer extends EventEmitter {
       if (this.heartbeatInterval) {
         heartbeat = this.startHeartbeat(async (elapsedSeconds) => {
           return this.changeVisibilityTimeout(message, elapsedSeconds + this.visibilityTimeout);
-        });
+        }, message);
       }
       await this.executeHandler(message);
       await this.deleteMessage(message);
@@ -235,11 +235,15 @@ export class Consumer extends EventEmitter {
       this.emitError(err, message);
 
       if (this.terminateVisibilityTimeout) {
-        if (typeof this.terminateVisibilityTimeout === 'function') {
-          const visibilityTimeout = this.terminateVisibilityTimeout(message);
-          await this.changeVisibilityTimeout(message, visibilityTimeout);
-        } else {
-          await this.changeVisibilityTimeout(message, 0);
+        try {
+          if (typeof this.terminateVisibilityTimeout === 'function') {
+            const visibilityTimeout = this.terminateVisibilityTimeout(message);
+            await this.changeVisibilityTimeout(message, visibilityTimeout);
+          } else {
+            await this.changeVisibilityTimeout(message, 0);
+          }
+        } catch (err) {
+          this.emit('error', err, message);
         }
       }
     } finally {
@@ -309,17 +313,13 @@ export class Consumer extends EventEmitter {
   }
 
   private async changeVisibilityTimeout(message: SQSMessage, timeout: number): Promise<PromiseResult<any, AWSError>> {
-    try {
-      return this.sqs
-        .changeMessageVisibility({
-          QueueUrl: this.queueUrl,
-          ReceiptHandle: message.ReceiptHandle,
-          VisibilityTimeout: timeout
-        })
-        .promise();
-    } catch (err) {
-      this.emit('error', err, message);
-    }
+    return this.sqs
+      .changeMessageVisibility({
+        QueueUrl: this.queueUrl,
+        ReceiptHandle: message.ReceiptHandle,
+        VisibilityTimeout: timeout
+      })
+      .promise();
   }
 
   private emitError(err: Error, message: SQSMessage): void {
@@ -375,7 +375,7 @@ export class Consumer extends EventEmitter {
       if (this.heartbeatInterval) {
         heartbeat = this.startHeartbeat(async (elapsedSeconds) => {
           return this.changeVisibilityTimeoutBatch(messages, () => elapsedSeconds + this.visibilityTimeout);
-        });
+        }, messages);
       }
       await this.executeBatchHandler(messages);
       await this.deleteMessageBatch(messages);
@@ -386,10 +386,14 @@ export class Consumer extends EventEmitter {
       this.emit('error', err, messages);
 
       if (this.terminateVisibilityTimeout) {
-        if (typeof this.terminateVisibilityTimeout === 'function') {
-          await this.changeVisibilityTimeoutBatch(messages, this.terminateVisibilityTimeout);
-        } else {
-          await this.changeVisibilityTimeoutBatch(messages, () => 0);
+        try {
+          if (typeof this.terminateVisibilityTimeout === 'function') {
+            await this.changeVisibilityTimeoutBatch(messages, this.terminateVisibilityTimeout);
+          } else {
+            await this.changeVisibilityTimeoutBatch(messages, () => 0);
+          }
+        } catch (err) {
+          this.emit('error', err, messages);
         }
       }
     } finally {
@@ -435,20 +439,18 @@ export class Consumer extends EventEmitter {
         VisibilityTimeout: getTimeout(message)
       }))
     };
-    try {
-      return this.sqs
-        .changeMessageVisibilityBatch(params)
-        .promise();
-    } catch (err) {
-      this.emit('error', err, messages);
-    }
+    return this.sqs
+      .changeMessageVisibilityBatch(params)
+      .promise();
   }
 
-  private startHeartbeat(heartbeatFn: (elapsedSeconds: number) => void): NodeJS.Timeout {
+  private startHeartbeat(heartbeatFn: (elapsedSeconds: number) => Promise<void>, message: SQSMessage | SQSMessage[]): NodeJS.Timeout {
     const startTime = Date.now();
     return setInterval(() => {
       const elapsedSeconds = Math.ceil((Date.now() - startTime) / 1000);
-      heartbeatFn(elapsedSeconds);
+      heartbeatFn(elapsedSeconds).catch((err) => {
+        this.emit('error', err, message);
+      });
     }, this.heartbeatInterval * 1000);
   }
 }

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -759,6 +759,108 @@ describe('Consumer', () => {
       });
       sandbox.assert.calledOnce(clearIntervalSpy);
     });
+
+    it('emits error event when heartbeat fails due to invalid receipt handle', async () => {
+      const heartbeatError = new Error(
+        'Value xyz for parameter ReceiptHandle is invalid. Reason: Message does not exist or is not available for visibility timeout change.'
+      );
+      sqs.changeMessageVisibility = stubReject(heartbeatError);
+
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        region: 'some-region',
+        handleMessage: () => new Promise((resolve) => setTimeout(resolve, 75000)),
+        sqs,
+        visibilityTimeout: 40,
+        heartbeatInterval: 30
+      });
+
+      let emittedError: Error | undefined;
+      let emittedMessage: any;
+      consumer.on('error', (err, msg) => {
+        emittedError = err;
+        emittedMessage = msg;
+      });
+
+      consumer.start();
+      await clock.tickAsync(30001);
+      consumer.stop();
+
+      assert.ok(emittedError);
+      assert.equal(emittedError!.message, heartbeatError.message);
+      assert.equal(emittedMessage.ReceiptHandle, 'receipt-handle');
+    });
+
+    it('emits error event when batch heartbeat fails due to invalid receipt handle', async () => {
+      const heartbeatError = new Error(
+        'Value xyz for parameter ReceiptHandle is invalid. Reason: Message does not exist or is not available for visibility timeout change.'
+      );
+      sqs.receiveMessage = stubResolve({
+        Messages: [
+          { MessageId: '1', ReceiptHandle: 'receipt-handle-1', Body: 'body-1' },
+          { MessageId: '2', ReceiptHandle: 'receipt-handle-2', Body: 'body-2' }
+        ]
+      });
+      sqs.changeMessageVisibilityBatch = stubReject(heartbeatError);
+
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        region: 'some-region',
+        handleMessageBatch: () => new Promise((resolve) => setTimeout(resolve, 75000)),
+        batchSize: 2,
+        sqs,
+        visibilityTimeout: 40,
+        heartbeatInterval: 30
+      });
+
+      let emittedError: Error | undefined;
+      let emittedMessages: any;
+      consumer.on('error', (err, msgs) => {
+        emittedError = err;
+        emittedMessages = msgs;
+      });
+
+      consumer.start();
+      await clock.tickAsync(30001);
+      consumer.stop();
+
+      assert.ok(emittedError);
+      assert.equal(emittedError!.message, heartbeatError.message);
+      assert.isArray(emittedMessages);
+      assert.equal(emittedMessages.length, 2);
+    });
+
+    it('does not crash when heartbeat error occurs', async () => {
+      const heartbeatError = new Error(
+        'Value xyz for parameter ReceiptHandle is invalid. Reason: Message does not exist.'
+      );
+      sqs.changeMessageVisibility = stubReject(heartbeatError);
+
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        region: 'some-region',
+        handleMessage: () => new Promise((resolve) => setTimeout(resolve, 75000)),
+        sqs,
+        visibilityTimeout: 40,
+        heartbeatInterval: 30
+      });
+
+      const errors: Error[] = [];
+      consumer.on('error', (err) => {
+        errors.push(err);
+      });
+
+      consumer.start();
+      // Tick past multiple heartbeats - all should be caught and emitted
+      await clock.tickAsync(65000);
+      consumer.stop();
+
+      // Multiple heartbeat errors should have been emitted (at 30s and 60s)
+      assert.isAtLeast(errors.length, 2);
+      errors.forEach((err) => {
+        assert.equal(err.message, heartbeatError.message);
+      });
+    });
   });
 
   describe('.stop', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

When heartbeats fail, it causes an unhandled promise rejection. This causes our downstream subscribers to crash. 

It's easy to forget to add that handler, so this catches those rejections and emits them as errors for the application-level consumer error handler to handle, keeping the process from crashing

<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
